### PR TITLE
Order's Invoice and TrackingCode update methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Gem for the Intelipost API
 require 'intelipost'
 
 client = Intelipost::Client.new api_key: <your api key>
-address = client.cep.address_complete '05307000'
+address = client.cep.address_complete.get '05307000'
 # => #<Hashie::Mash content=#<Hashie::Mash bairro="Vila Ribeiro de Barros" city="São Paulo" ibge="3550308" neighborhood="Vila Ribeiro de Barros" state="São Paulo" state_short="SP" street="R Maj Paladino"> messages=[] status="OK" time="0.6 ms">
 address.content.street
 # => "R Maj Paladino"
@@ -37,6 +37,22 @@ require 'intelipost'
 
 client = Intelipost::Client.new api_key: <your api key>
 client.shipment_order.create({hash_of: :intelipost, args: :values})
+````
+
+````ruby
+# POST /shipment_order/set_invoice
+require 'intelipost'
+
+client = Intelipost::Client.new api_key: <your api key>
+client.shipment_order.set_invoice.update({hash_of: :intelipost, args: :values})
+````
+
+````ruby
+# POST /shipment_order/set_tracking_data
+require 'intelipost'
+
+client = Intelipost::Client.new api_key: <your api key>
+client.shipment_order.set_tracking_data.update({hash_of: :intelipost, args: :values})
 ````
 
 ### Development:

--- a/lib/intelipost/fluent_interface.rb
+++ b/lib/intelipost/fluent_interface.rb
@@ -10,11 +10,25 @@ module Intelipost
 
     module InstanceMethods
       def create(post_values)
-        connection.post(endpoint, post_values)
+        connection.post(@fluent_interfaces.join('/'), post_values)
+      end
+
+      def update(post_values)
+        create(post_values)
+      end
+
+      def get(value)
+        connection.get([@fluent_interfaces, value].join('/'))
       end
 
       def method_missing(method, *args, &block)
-        connection.get [endpoint, method, args].join '/'
+        add_fluent_interface_path(method)
+        self
+      end
+
+      private
+      def add_fluent_interface_path(method)
+        @fluent_interfaces << method
       end
     end
   end
@@ -26,6 +40,7 @@ module Intelipost
 
     def initialize(connection)
       @connection = connection
+      @fluent_interfaces = [endpoint]
     end
 
     def spawn

--- a/spec/lib/intelipost/cep_spec.rb
+++ b/spec/lib/intelipost/cep_spec.rb
@@ -4,7 +4,7 @@ describe Intelipost::Cep do
   describe '#address_complete' do
     it 'correctly queries the cep' do
       expect(subject.connection).to receive(:get).with('cep_location/address_complete/00000000')
-      subject.address_complete '00000000'
+      subject.address_complete.get '00000000'
     end
   end
 end

--- a/spec/lib/intelipost/client_spec.rb
+++ b/spec/lib/intelipost/client_spec.rb
@@ -39,7 +39,7 @@ describe Intelipost::Client, :vcr do
 
   context 'dealing with zipcode (cep)' do
     it 'returns a Hashie::Mash on successful query' do
-      expect(subject.cep.address_complete('04661100').class).to be Hashie::Mash
+      expect(subject.cep.address_complete.get('04661100').class).to be Hashie::Mash
     end
   end
 

--- a/spec/lib/intelipost/shipment_order_spec.rb
+++ b/spec/lib/intelipost/shipment_order_spec.rb
@@ -61,17 +61,17 @@ describe Intelipost::ShipmentOrder do
 
   let(:order_invoice) do
     {
-      'order_number': '12314324',
-      'shipment_order_volume_invoice_array': [
+      'order_number' => '12314324',
+      'shipment_order_volume_invoice_array' => [
         {
-          'shipment_order_volume_number':'1',
-          'invoice_series':'123123123',
-          'invoice_number':'BR283248123',
-          'invoice_key':'CDFx2342396078192310231982',
-          'invoice_date':'2014-02-28',
-          'invoice_total_value':'32,49',
-          'invoice_products_value':'28,99',
-          'invoice_cfop': '5120'
+          'shipment_order_volume_number' =>'1',
+          'invoice_series' =>'123123123',
+          'invoice_number' =>'BR283248123',
+          'invoice_key' =>'CDFx2342396078192310231982',
+          'invoice_date' =>'2014-02-28',
+          'invoice_total_value' =>'32,49',
+          'invoice_products_value' =>'28,99',
+          'invoice_cfop' => '5120'
         }
       ]
     }
@@ -84,15 +84,15 @@ describe Intelipost::ShipmentOrder do
 
   let(:order_tracking_code) do
     {
-      'order_number': 'BR12345',
-      'tracking_data_array': [
+      'order_number' => 'BR12345',
+      'tracking_data_array' => [
       {
-        'shipment_order_volume_number':1,
-        'tracking_code': 'SW123456789BR'
+        'shipment_order_volume_number' =>1,
+        'tracking_code' => 'SW123456789BR'
       },
       {
-        'shipment_order_volume_number':2,
-        'tracking_code': 'SW123456789BR'
+        'shipment_order_volume_number' =>2,
+        'tracking_code' => 'SW123456789BR'
       }
       ]
     }

--- a/spec/lib/intelipost/shipment_order_spec.rb
+++ b/spec/lib/intelipost/shipment_order_spec.rb
@@ -64,13 +64,13 @@ describe Intelipost::ShipmentOrder do
       'order_number' => '12314324',
       'shipment_order_volume_invoice_array' => [
         {
-          'shipment_order_volume_number' =>'1',
-          'invoice_series' =>'123123123',
-          'invoice_number' =>'BR283248123',
-          'invoice_key' =>'CDFx2342396078192310231982',
-          'invoice_date' =>'2014-02-28',
-          'invoice_total_value' =>'32,49',
-          'invoice_products_value' =>'28,99',
+          'shipment_order_volume_number' => '1',
+          'invoice_series' => '123123123',
+          'invoice_number' => 'BR283248123',
+          'invoice_key' => 'CDFx2342396078192310231982',
+          'invoice_date' => '2014-02-28',
+          'invoice_total_value' => '32,49',
+          'invoice_products_value' => '28,99',
           'invoice_cfop' => '5120'
         }
       ]
@@ -87,11 +87,11 @@ describe Intelipost::ShipmentOrder do
       'order_number' => 'BR12345',
       'tracking_data_array' => [
       {
-        'shipment_order_volume_number' =>1,
+        'shipment_order_volume_number' => 1,
         'tracking_code' => 'SW123456789BR'
       },
       {
-        'shipment_order_volume_number' =>2,
+        'shipment_order_volume_number' => 2,
         'tracking_code' => 'SW123456789BR'
       }
       ]

--- a/spec/lib/intelipost/shipment_order_spec.rb
+++ b/spec/lib/intelipost/shipment_order_spec.rb
@@ -58,4 +58,48 @@ describe Intelipost::ShipmentOrder do
     expect(subject.connection).to receive(:post).with('shipment_order', order_to_ship)
     subject.create(order_to_ship)
   end
+
+  let(:order_invoice) do
+    {
+      'order_number': '12314324',
+      'shipment_order_volume_invoice_array': [
+        {
+          'shipment_order_volume_number':'1',
+          'invoice_series':'123123123',
+          'invoice_number':'BR283248123',
+          'invoice_key':'CDFx2342396078192310231982',
+          'invoice_date':'2014-02-28',
+          'invoice_total_value':'32,49',
+          'invoice_products_value':'28,99',
+          'invoice_cfop': '5120'
+        }
+      ]
+    }
+  end
+
+  it 'invoice update' do
+    expect(subject.connection).to receive(:post).with('shipment_order/set_invoice', order_invoice)
+    subject.set_invoice.update(order_invoice)
+  end
+
+  let(:order_tracking_code) do
+    {
+      'order_number': 'BR12345',
+      'tracking_data_array': [
+      {
+        'shipment_order_volume_number':1,
+        'tracking_code': 'SW123456789BR'
+      },
+      {
+        'shipment_order_volume_number':2,
+        'tracking_code': 'SW123456789BR'
+      }
+      ]
+    }
+  end
+
+  it 'tracking update' do
+    expect(subject.connection).to receive(:post).with('shipment_order/set_tracking_data', order_tracking_code)
+    subject.set_tracking_data.update(order_tracking_code)
+  end
 end


### PR DESCRIPTION
Refers to #5.
**Please, merge #4 before this one.** #4 may break this PR, requiring merge master here.

Also, this PR will change how _FluentInterface_ works: now, every method should end with one of the following methods: `get`, `create`, `update`.
The major modification was on `cep.address_complete` which now requires a `get` in the end: `cep.address_complete.get('zipcode')`

This way, we can keep the same pattern for all Intelipost API's endpoints, encapsulating all URL differences from it. 
